### PR TITLE
Always load Unconfirmed on `plugins_loaded`

### DIFF
--- a/unconfirmed.php
+++ b/unconfirmed.php
@@ -934,7 +934,13 @@ class BBG_Unconfirmed {
 	}
 }
 
-$bbg_unconfirmed = new BBG_Unconfirmed;
+function BBG_Unconfirmed() {
+	global $bbg_unconfirmed;
 
+	if ( empty( $bbg_unconfirmed ) ) {
+		$bbg_unconfirmed = new BBG_Unconfirmed;
+	}
 
-?>
+	return $bbg_unconfirmed;
+}
+add_action( 'plugins_loaded', 'BBG_Unconfirmed' );


### PR DESCRIPTION
Fixes situations in which Unconfirmed is required as a MU plugin, but filters need to be applied before the class is loaded. My specific situation is that I need to filter the network admin URL because of a core bug.
