### PR TITLE
Fix incorrect use of `$wpdb->prepare()`

### DIFF
--- a/unconfirmed.php
+++ b/unconfirmed.php
@@ -566,11 +566,11 @@ class BBG_Unconfirmed {
 
 				if ( $this->is_multisite ) {
 					foreach( (array)$activation_keys as $ak_index => $activation_key ) {
-						$activation_keys[$ak_index] = '"' . $activation_key . '"';
+						$activation_keys[$ak_index] = '"' . sanitize_text_field( $activation_key ) . '"';
 					}
 					$activation_keys = implode( ',', $activation_keys );
 
-					$registrations = $wpdb->get_results( $wpdb->prepare( "SELECT user_email, activation_key FROM $wpdb->signups WHERE activation_key IN ({$activation_keys})" ) );
+					$registrations = $wpdb->get_results( "SELECT user_email, activation_key FROM $wpdb->signups WHERE activation_key IN ({$activation_keys})" );
 				} else {
 					$registrations = array();
 					foreach ( (array)$activation_keys as $akey ) {


### PR DESCRIPTION
Resolves this error:

```
Warning: Missing argument 2 for wpdb::prepare(), called in /srv/www/digitalfirstmedia.dev/content/mu-plugins/unconfirmed/unconfirmed.php on line 573 and defined in /srv/www/digitalfirstmedia.dev/wp/wp-includes/wp-db.php on line 1138
```
