### PR TITLE
Remove PHP 4 constructors

### DIFF
--- a/lib/boones-pagination.php
+++ b/lib/boones-pagination.php
@@ -7,49 +7,39 @@ class BBG_CPT_Pag {
 	 * The CPT query. Defaults to $wp_query; see BBG_CPT_Pag::setup_query()
 	 */
 	var $query;
-	
+
 	/**
 	 * The desired $_GET keys for per_page and paged
 	 */
 	var $get_per_page_key;
 	var $get_paged_key;
-	
+
 	/**
 	 * The values of per_page and paged as retrieved from $_GET
 	 */
 	var $get_per_page;
 	var $get_paged;
-	
+
 	/**
 	 * The number of items found, and the total page number based on this
 	 */
 	var $total_items;
 	var $total_pages;
-	
+
 	/**
-	 * PHP 4 constructor
+	 * Constructor.
 	 *
 	 * @package Boone's Pagination
 	 * @since 1.0
 	 */
-	function bbg_cpt_pag() {
-		$this->__construct();
-	}
-
-	/**
-	 * PHP 5 constructor
-	 *
-	 * @package Boone's Pagination
-	 * @since 1.0
-	 */	
-	function __construct( $query = false ) {		
+	function __construct( $query = false ) {
 		// Set up the $_GET keys (which are customizable)
 		$this->setup_get_keys();
-		
+
 		// Get the pagination parameters out of $_GET
-		$this->setup_get_params();	
+		$this->setup_get_params();
 	}
-	
+
 	/**
 	 * Sets up query vars.
 	 *
@@ -69,19 +59,19 @@ class BBG_CPT_Pag {
 	 */
 	function setup_query( $query = false ) {
 		global $wp_query;
-		
+
 		if ( !$query )
 			$query =& $wp_query;
-			
+
 		$this->query = $query;
-	
+
 		// Get the total number of items
 		$this->setup_total_items();
-		
+
 		// Get the total number of pages
-		$this->setup_total_pages();	
+		$this->setup_total_pages();
 	}
-	
+
 	/**
 	 * Sets up the $_GET param keys.
 	 *
@@ -93,7 +83,7 @@ class BBG_CPT_Pag {
 	 */
 	function setup_get_keys() {
 		$this->get_per_page_key = apply_filters( 'bbg_cpt_pag_per_page_key', 'per_page' );
-		
+
 		/**
 		 * I chose 'paged' as the default not because I like it - I don't - but because
 		 * other choices threatened to interfere with native WP functions. In particular,
@@ -101,7 +91,7 @@ class BBG_CPT_Pag {
 		 */
 		$this->get_paged_key 	= apply_filters( 'bbg_cpt_pag_paged_key', 'paged' );
 	}
-	
+
 	/**
 	 * Gets params out of $_GET global
 	 *
@@ -113,23 +103,23 @@ class BBG_CPT_Pag {
 	function setup_get_params() {
 		// Per page
 		$per_page = isset( $_GET[$this->get_per_page_key] ) ? $_GET[$this->get_per_page_key] : 10;
-		
+
 		// Basic per_page sanity and security
 		if ( !(int)$per_page )
 			$per_page = 10;
-		
+
 		$this->get_per_page = $per_page;
-		
-		// Page number		
+
+		// Page number
 		$paged = isset( $_GET[$this->get_paged_key] ) ? $_GET[$this->get_paged_key] : 1;
-		
+
 		// Basic paged sanity and security
 		if ( !(int)$paged )
 			$paged = 1;
-		
+
 		$this->get_paged = $paged;
 	}
-	
+
 	/**
 	 * Get the total number of items out of the query
 	 *
@@ -139,7 +129,7 @@ class BBG_CPT_Pag {
 	function setup_total_items() {
 		$this->total_items = $this->query->found_posts;
 	}
-	
+
 	/**
 	 * Get the total number of pages out of the query
 	 *
@@ -149,7 +139,7 @@ class BBG_CPT_Pag {
 	function setup_total_pages() {
 		$this->total_pages = $this->query->max_num_pages;
 	}
-	
+
 	/**
 	 * Get the start number for the current view (ie "Viewing *5* - 8 of 12")
 	 *
@@ -161,12 +151,12 @@ class BBG_CPT_Pag {
 	 *
 	 * @return int $start The start number
 	 */
-	function get_start_number() {		
+	function get_start_number() {
 		$start = ( ( $this->get_paged - 1 ) * $this->get_per_page ) + 1;
-		
+
 		return $start;
 	}
-	
+
 	/**
 	 * Get the end number for the current view (ie "Viewing 5 - *8* of 12")
 	 *
@@ -181,15 +171,15 @@ class BBG_CPT_Pag {
 	 */
 	function get_end_number() {
 		global $wp_query;
-		
+
 		$end = $this->get_paged * $this->get_per_page;
-		
+
 		if ( $end > $this->total_items )
 			$end = $this->total_items;
-		
+
 		return $end;
 	}
-	
+
 	/**
 	 * Return or echo the "Viewing x-y of z" message
 	 *
@@ -199,18 +189,18 @@ class BBG_CPT_Pag {
 	 * @param str $type Optional. 'echo' will echo the results, anything else will return them
 	 * @return str $page_links The "viewing" text
 	 */
-	function currently_viewing_text( $type = 'echo' ) {	 
+	function currently_viewing_text( $type = 'echo' ) {
 		$start  = $this->get_start_number();
 		$end	= $this->get_end_number();
-		
+
 		$string = sprintf( __( 'Viewing %1$d - %2$d of a total of %3$d', 'bbg-cpt-pag' ), $start, $end, $this->total_items );
-		
+
 		if ( 'echo' == $type )
 			echo $string;
 		else
 			return $string;
 	}
-	
+
 	/**
 	 * Return or echo the pagination links
 	 *
@@ -231,7 +221,7 @@ class BBG_CPT_Pag {
 			'current' 	=> $this->get_paged,
 			'add_args'	=> $add_args
 		));
-		
+
 		if ( 'echo' == $type )
 			echo $page_links;
 		else

--- a/lib/boones-sortable-columns.php
+++ b/lib/boones-sortable-columns.php
@@ -7,57 +7,47 @@ class BBG_CPT_Sort {
 	 * The full column data
 	 */
 	var $columns;
-	
+
 	var $column_count;
 	var $current_column;
 	var $column;
 	var $in_the_loop;
-	
+
 	/**
 	 * Default orderby column
 	 */
 	var $default_orderby;
-	
+
 	/**
 	 * The desired $_GET keys for orderby and order
 	 */
 	var $get_orderby_key;
 	var $get_order_key;
-	
+
 	/**
 	 * The values of orderby and order as retrieved from $_GET
 	 */
 	var $get_orderby;
 	var $get_order;
-	
+
 	var $sortable_keys;
-	
+
 	/**
 	 * The URL used as a base for concatenating links
 	 */
 	var $base_url;
-	
-	/**
-	 * PHP 4 constructor
-	 *
-	 * @package Boone's Sortable Columns
-	 * @since 1.0
-	 */
-	function bbg_cpt_sort( $cols = false ) {
-		$this->__construct( $cols );
-	}
 
 	/**
-	 * PHP 5 constructor
+	 * Constructor.
 	 *
 	 * @package Boone's Sortable Columns
 	 * @since 1.0
 	 *
 	 * $columns should be an array of arrays. That is, an array of args for each column. See
 	 * $defaults below for an explanation of these arrays.
-	 */	
+	 */
 	function __construct( $cols = false ) {
-		
+
 		/**
 		 * This defines the default values for *each column*. Please note that the $cols
 		 * param for this method is an array of arrays like this.
@@ -71,9 +61,9 @@ class BBG_CPT_Sort {
 		 * 		understood by WP_Query, or because you're not sorting a WP_Query)
 		 *		you'll have to do some translation between this 'name' value and
 		 *		your actual sorting code, whatever it is.
-		 *   - 'title'	The text that will be used to create the column header. 
+		 *   - 'title'	The text that will be used to create the column header.
 		 *   - 'is_sortable' True if you want the column to be sortable, false if not
-		 *   - 'css_class' This object will create a CSS selector that is tailored for use 
+		 *   - 'css_class' This object will create a CSS selector that is tailored for use
 		 *		in <th> elements of WP Dashboard 'widefat' tables. That complex CSS
 		 *		selector will automatically contain classes like 'sortable' and
 		 *		'asc', depending on the parameters and on your current page.
@@ -97,69 +87,69 @@ class BBG_CPT_Sort {
 			'posts_column'	=> false,
 			'is_default'	=> false
 		);
-	
+
 		$this->columns = array();
 		$this->sortable_keys = array();
-	
+
 		foreach( $cols as $col ) {
 			// You need at least a name and a title to continue
 			if ( empty( $col['name'] ) || empty( $col['title'] ) )
 				continue;
-				
+
 			$r = wp_parse_args( $col, $defaults );
-			
+
 			// If the css_class is not set, just use the name param
 			if ( empty( $r['css_class'] ) )
 				$r['css_class'] = $r['name'];
-		
+
 			// Check to see whether this is a default. Providing more than one default
 			// will mean that the last one overrides the others
 			if ( !empty( $r['is_default'] ) )
 				$this->default_orderby = $r['name'];
-		
+
 			// Compare the default order against a whitelist of 'asc' and 'desc'
 			if ( 'asc' == strtolower( $r['default_order'] ) || 'desc' == strtolower( $r['default_order'] ) ) {
 				$r['default_order'] = strtolower( $r['default_order'] );
 			} else {
 				$r['default_order'] = 'asc';
 			}
-			
+
 			// If it's sortable, add the name to the $sortable_keys array
 			if ( $r['is_sortable'] )
 				$this->sortable_keys[] = $r['name'];
-		
+
 			// Convert to an object for maximum prettiness
 			$col_obj = new stdClass;
-			
+
 			foreach( $r as $key => $value ) {
 				$col_obj->$key = $value;
 			}
-			
+
 			$this->columns[] = $col_obj;
 		}
-					
+
 		// Now, set up some values for the loop
 		$this->column_count = count( $this->columns );
 		$this->current_column = -1;
-		
+
 		// If a default orderby was not found, just choose the first item in the array
 		if ( empty( $this->default_orderby ) && !empty( $cols[0]['name'] ) ) {
 			$this->default_orderby = $cols[0]['name'];
 		}
-		
+
 		// Set up the $_GET keys (which are customizable)
 		$this->setup_get_keys();
-		
+
 		// Get the pagination parameters out of $_GET
 		$this->setup_get_params();
-		
+
 		// Set up the next orders (asc or desc) depending on current state
 		$this->setup_next_orders();
-	
+
 		// Set up the URL to be used as a base for href links
 		$this->setup_base_url();
 	}
-	
+
 	/**
 	 * Sets up the $_GET param keys.
 	 *
@@ -173,7 +163,7 @@ class BBG_CPT_Sort {
 		$this->get_orderby_key	= apply_filters( 'bbg_cpt_sort_orderby_key', 'orderby' );
 		$this->get_order_key 	= apply_filters( 'bbg_cpt_sort_order_key', 'order' );
 	}
-	
+
 	/**
 	 * Gets params out of $_GET global
 	 *
@@ -187,18 +177,18 @@ class BBG_CPT_Sort {
 	function setup_get_params() {
 		// Orderby
 		$orderby = isset( $_GET[$this->get_orderby_key] ) ? $_GET[$this->get_orderby_key] : false;
-		
+
 		// If an orderby param is provided, check to see that it's permitted.
 		// Otherwise set the current orderby to the default
 		if ( $orderby && in_array( $orderby, $this->sortable_keys ) ) {
 			$this->get_orderby = $orderby;
 		} else {
-			$this->get_orderby = $this->default_orderby;		
+			$this->get_orderby = $this->default_orderby;
 		}
-		
-		// Order	
+
+		// Order
 		$order = isset( $_GET[$this->get_order_key] ) ? $_GET[$this->get_order_key] : false;
-		
+
 		// If an order is provided, make sure it's either 'desc' or 'asc'
 		// Otherwise set current order to the orderby's default order
 		if ( $order && ( 'desc' == strtolower( $order ) || 'asc' == strtolower( $order ) ) ) {
@@ -208,20 +198,20 @@ class BBG_CPT_Sort {
 			// This is not optimized because of the way the array is keyed
 			// Cry me a river why don't you
 			foreach( $this->columns as $col ) {
-				if ( $col->name == $this->get_orderby ) {	
+				if ( $col->name == $this->get_orderby ) {
 					$order = $col->default_order;
 					break;
 				}
 			}
 		}
-		
+
 		// There should only be two options, 'asc' and 'desc'. We'll cut some slack for
 		// uppercase variants
 		$order = 'desc' == strtolower( $order ) ? 'desc' : 'asc';
-		
+
 		$this->get_order = $order;
 	}
-	
+
 	/**
 	 * Loops through the columns and determines what the next_order should be
 	 *
@@ -244,25 +234,25 @@ class BBG_CPT_Sort {
 			} else {
 				$next_order = $col->default_order;
 			}
-			
+
 			$this->columns[$name]->next_order = $next_order;
 		}
 	}
-	
+
 	/**
 	 * Set the base url that will be used for creating links
 	 *
 	 * By default, Boone's Sortable Columns will use your current URL as the base for creating
 	 * the clickable headers. (To be more specific, it uses add_query_arg() with a null value
-	 * for the query/url param, so that it defaults to $_SERVER['REQUEST_URI']. See 
+	 * for the query/url param, so that it defaults to $_SERVER['REQUEST_URI']. See
 	 * add_query_arg() for more details.)
 	 *
-	 * In some cases, you may want to use a special URL for this purpose. For instance, you may 
+	 * In some cases, you may want to use a special URL for this purpose. For instance, you may
 	 * want to remove certain query argument. In this function, I assume that you *always* want
-	 * to remove _wpnonce, since that should be generated on the fly. I also assume that when 
+	 * to remove _wpnonce, since that should be generated on the fly. I also assume that when
 	 * a column is resorted, pagination should be reset (thus the presence of 'paged' and
 	 * 'per_page' on the blacklist). If you want to remove additional query arguments (such as
-	 * those used to generate success messages, etc), filter 
+	 * those used to generate success messages, etc), filter
 	 * boones_sortable_columns_keys_to_remove.
 	 *
 	 * You can also override this behavior by feeding your own custom value to the method,
@@ -279,21 +269,21 @@ class BBG_CPT_Sort {
 	function setup_base_url( $url = false ) {
 		if ( !$url ) {
 			$current_keys = array_keys( $_GET );
-			
+
 			// These are keys that will always be removed from the base url
 			$keys_to_remove = apply_filters( 'boones_sortable_columns_keys_to_remove', array(
 				'_wpnonce',
 				'paged'
 			) );
-		
+
 			foreach( $keys_to_remove as $key ) {
 				$url = remove_query_arg( $key, $url );
 			}
 		}
-		
+
 		$this->base_url = $url;
 	}
-	
+
 	/**
 	 * Part of the Loop
 	 *
@@ -355,7 +345,7 @@ class BBG_CPT_Sort {
 		if ( 0 == $this->current_column ) // loop has just started
 			do_action('loop_start');
 	}
-	
+
 	/**
 	 * Constructs a complex CSS selector for the column header
 	 *
@@ -377,7 +367,7 @@ class BBG_CPT_Sort {
 	function the_column_css_class( $type = 'echo' ) {
 		// The column-identifying class
 		$class = array( $this->column->css_class );
-		
+
 		// Sortable logic
 		if ( $this->column->is_sortable ) {
 			// Add the sorted/sortable class, based on whether this is the current sort
@@ -389,15 +379,15 @@ class BBG_CPT_Sort {
 				$class[] = 'asc' == $this->column->default_order ? 'desc' : 'asc';
 			}
 		}
-		
+
 		$class = implode( ' ', $class );
-		
+
 		if ( 'echo' == $type )
 			echo $class;
 		else
 			return $class;
 	}
-	
+
 	/**
 	 * Constructs the href URL for the column header
 	 *
@@ -406,23 +396,23 @@ class BBG_CPT_Sort {
 	 *
 	 * Sortable columns work by turning each column header into a link that, when clicked, will
 	 * return new results that are sorted based on your requests. Making the URLs for those
-	 * links can be complex, however. This method will do all the heavy lifting for you, 
+	 * links can be complex, however. This method will do all the heavy lifting for you,
 	 * producing a URL or an entire anchor tag that you can use as the column header.
 	 *
 	 * For example, let's say your current URL is http://example.com/restaurants, which displays
 	 * a list of restaurants which are, by default, sorted by restaurant name, in ascending
 	 * alphabetical order. The column header for the Restaurant Name column should be a link
 	 * to sort the list by restaurant name in *descending* alphabetical order, while, for
-	 * example, the Cuisine column should be a link to sort the list by cuisine type, in 
+	 * example, the Cuisine column should be a link to sort the list by cuisine type, in
 	 * ascending order. Accordingly (assuming you've instantiated the class properly; see
 	 * readme.txt for more instructions), the following lines of code
-	 * 
-	 *   <?php if ( $sortable->have_columns() ) : ?> 
+	 *
+	 *   <?php if ( $sortable->have_columns() ) : ?>
 	 *      <?php while ( $sortable->have_columns() ) : $sortable->the_column() ?>
 	 *	   <?php $sortable->the_column_next_link() ?>
 	 *	<?php endwhile ?>
 	 *   <?php endif ?>
-	 * 
+	 *
 	 * will output the following HTML:
 	 *
 	 *   <a href="http://example.com/restaurants?orderby=restaurant_name&order=desc">Restaurant
@@ -444,24 +434,24 @@ class BBG_CPT_Sort {
 			$this->get_orderby_key	=> $this->column->name,
 			$this->get_order_key	=> $this->column->next_order
 		);
-		
+
 		$url = add_query_arg( $args, $this->base_url );
-		
+
 		// Assemble the html link, if necessary
 		if ( 'html' == $html_or_url ) {
 			$html = sprintf( '<a title="%1$s" href="%2$s">%3$s</a>', $this->column->name, $url, $this->the_column_title( 'return' ) );
-			
+
 			$link = $html;
 		} else {
 			$link = $url;
 		}
-		
+
 		if ( 'echo' == $type )
 			echo $link;
 		else
 			return $link;
 	}
-	
+
 	/**
 	 * Gets the title text for the column header
 	 *
@@ -476,13 +466,13 @@ class BBG_CPT_Sort {
 	 */
 	function the_column_title( $type = 'echo' ) {
 		$name = $this->column->title;
-		
+
 		if ( 'echo' == $type )
 			echo $name;
 		else
 			return $name;
 	}
-	
+
 	/**
 	 * Constructs a <th> column header element out of the column data
 	 *
@@ -511,11 +501,11 @@ class BBG_CPT_Sort {
 			$td_content = sprintf( '<a href="%1$s"><span>%2$s</span><span class="sorting-indicator"></span></a>', $this->the_column_next_link( 'return', 'url' ), $this->the_column_title( 'return' ) );
 		} else {
 			$td_content = $this->the_column_title( 'return' );
-		
+
 		}
-	
+
 		$html = sprintf( '<th scope="col" class="manage-column %1$s">%2$s</th>', $this->the_column_css_class( 'return' ), $td_content );
-		
+
 		if ( 'echo' == $type )
 			echo $html;
 		else

--- a/unconfirmed.php
+++ b/unconfirmed.php
@@ -37,7 +37,7 @@ class BBG_Unconfirmed {
 	var $is_multisite;
 
 	/**
-	 * PHP 5 constructor
+	 * Constructor.
 	 *
 	 * This function sets up a base url to use for URL concatenation throughout the plugin.
 	 *
@@ -64,16 +64,6 @@ class BBG_Unconfirmed {
 		$admin_hook = apply_filters( 'unconfirmed_admin_hook', $this->is_multisite ? 'network_admin_menu' : 'admin_menu' );
 
 		add_action( $admin_hook, array( $this, 'add_admin_panel' ) );
-	}
-
-	/**
-	 * PHP 4 constructor
-	 *
-	 * @package Unconfirmed
-	 * @since 1.0
-	 */
-	function bbg_unconfirmed() {
-		$this->__construct();
 	}
 
 	/**


### PR DESCRIPTION
To avoid strict standards warnings from type "Redefining already defined constructor" it's time to remove the PHP 4 constructors.

PR also includes a whitespace cleanup. If wanted I can do a separated PR for this.
