### PR TITLE
Use plugins_url() instead of WP_PLUGIN_URL

### DIFF
--- a/unconfirmed.php
+++ b/unconfirmed.php
@@ -123,7 +123,7 @@ class BBG_Unconfirmed {
 	 * @uses wp_enqueue_style()
 	 */
 	function add_admin_styles() {
-		wp_enqueue_style( 'unconfirmed-css', WP_PLUGIN_URL . '/unconfirmed/css/style.css' );
+		wp_enqueue_style( 'unconfirmed-css', plugins_url( 'css/style.css', __FILE__ ) );
 	}
 
 	/**


### PR DESCRIPTION
Prevents mixed-content warning on Unconfirmed admin page when FORCE_SSL_ADMIN is true. See boonebgorges/unconfirmed#19.
