### PR TITLE
Fix incorrect usage of loop_start action causing issues with facetwp

### DIFF
--- a/lib/boones-sortable-columns.php
+++ b/lib/boones-sortable-columns.php
@@ -350,7 +350,7 @@ if ( ! class_exists( 'BBG_CPT_Sort' ) ) :
 			$this->column      = $this->next_column();
 
 			if ( 0 == $this->current_column ) { // loop has just started
-				do_action( 'loop_start' );
+				do_action( 'loop_start', $GLOBALS['wp_query']);
 			}
 		}
 


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/when-installed-with-facet-wp-unconfirmed-admin-page-breaks/